### PR TITLE
Add "invitations" command that provides a login link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+HOST_NAME="https://example.com"
 DATABASE_URL="file:./data.db?connection_limit=1"
 SESSION_SECRET="super-duper-s3cret"
 TWILIO_ACCOUNT_SID="twilio-account-id-goes-here"

--- a/app/messages/router.test.ts
+++ b/app/messages/router.test.ts
@@ -159,4 +159,21 @@ describe("existing member", () => {
     });
     expect(invite?.guests).toBe(5);
   });
+
+  it("the help command works", async () => {
+    const result = await handleMessage(phone, "help");
+    expect(result.response).toMatch(
+      /Respond with any of the following commands/i
+    );
+    expect(result.response).toMatch(/HELP/i);
+    expect(result.response).toMatch(/INVITATIONS/i);
+  });
+
+  it("the invitations command works", async () => {
+    const result = await handleMessage(phone, "invitations");
+    expect(result.response).toMatch(
+      /To view or update invitations and RSVPs, use this link/i
+    );
+    expect(result.response).toMatch(/\/memberLogin/i);
+  });
 });

--- a/app/messages/router.test.ts
+++ b/app/messages/router.test.ts
@@ -1,0 +1,162 @@
+import { prisma } from "~/db.server";
+import { getMembershipRequest } from "~/models/membership_request.server";
+import { handleMessage } from "./router";
+import addDays from "date-fns/addDays";
+import { sendInvite } from "~/models/invitation.server";
+
+const phone = "+15555555555";
+
+describe("unrecognized number", () => {
+  beforeEach(async () => {
+    await prisma.membershipRequest.deleteMany({
+      where: { phoneNumber: phone },
+    });
+    await prisma.member.deleteMany({
+      where: { phoneNumber: phone },
+    });
+  });
+
+  it("should create a membership request", async () => {
+    let result = await handleMessage(phone, "Hi");
+    expect(result.response).toMatch(/Respond with your name/i);
+
+    result = await handleMessage(phone, "Bobbie");
+    expect(result.response).toMatch(/Hello, Bobbie/i);
+
+    const request = await prisma.membershipRequest.findFirst({
+      where: {
+        phoneNumber: phone,
+      },
+    });
+
+    expect(request).toBeTruthy();
+  });
+});
+
+describe("existing member", () => {
+  beforeEach(async () => {
+    const member = await prisma.member.create({
+      data: {
+        name: "Bobbie",
+        phoneNumber: phone,
+        token: "fake-token",
+      },
+    });
+
+    const schedule = await prisma.schedule.create({
+      data: {
+        title: "My fake schedule",
+        cadence: "fake-cadence",
+        events: {
+          create: {
+            dateTime: addDays(new Date(), 3),
+          },
+        },
+      },
+      include: {
+        events: true,
+      },
+    });
+
+    sendInvite({
+      memberId: member.id,
+      eventId: schedule.events[0].id,
+    });
+
+    return async () => {
+      await prisma.schedule.delete({ where: { id: schedule.id } });
+      await prisma.member.delete({ where: { id: member.id } });
+    };
+  });
+
+  it("should let you respond YES", async () => {
+    let result = await handleMessage(phone, "YES");
+    expect(result.response).toMatch(/We look forward to seeing you/i);
+    const invite = await prisma.invitation.findFirst({
+      where: {
+        member: {
+          phoneNumber: phone,
+        },
+      },
+    });
+    expect(invite?.status).toBe("RESPONDED_YES");
+  });
+
+  it("should let you respond NO", async () => {
+    let result = await handleMessage(phone, "NO");
+    expect(result.response).toMatch(/catch you next time/i);
+    const invite = await prisma.invitation.findFirst({
+      where: {
+        member: {
+          phoneNumber: phone,
+        },
+      },
+    });
+    expect(invite?.status).toBe("RESPONDED_NO");
+  });
+
+  it("should let you respond MAYBE", async () => {
+    let result = await handleMessage(phone, "MAYBE");
+    expect(result.response).toMatch(/we'll follow up with you in a few days/i);
+    const invite = await prisma.invitation.findFirst({
+      where: {
+        member: {
+          phoneNumber: phone,
+        },
+      },
+    });
+    expect(invite?.status).toBe("RESPONDED_MAYBE");
+  });
+
+  it("should let you add guests after responding YES", async () => {
+    let result = await handleMessage(phone, "YES");
+    expect(result.response).toMatch(/We look forward to seeing you/i);
+    result = await handleMessage(phone, "2");
+    expect(result.response).toMatch(
+      /thanks for letting us know about your guests/i
+    );
+    const invite = await prisma.invitation.findFirst({
+      where: {
+        member: {
+          phoneNumber: phone,
+        },
+      },
+    });
+    expect(invite?.status).toBe("RESPONDED_YES");
+    expect(invite?.guests).toBe(2);
+  });
+
+  it("should prevent too few or too many guests", async () => {
+    let result = await handleMessage(phone, "YES");
+    expect(result.response).toMatch(/We look forward to seeing you/i);
+    result = await handleMessage(phone, "-5");
+    expect(result.response).toMatch(/negative guests/i);
+    result = await handleMessage(phone, "15");
+    expect(result.response).toMatch(/you have a lot of friends/i);
+    result = await handleMessage(phone, "not a number");
+    expect(result.response).toMatch(/Please type a number between 1-10/i);
+    const invite = await prisma.invitation.findFirst({
+      where: {
+        member: {
+          phoneNumber: phone,
+        },
+      },
+    });
+    expect(invite?.status).toBe("RESPONDED_YES");
+    expect(invite?.guests).toBe(null);
+  });
+
+  it("should let you change the number of guests", async () => {
+    await handleMessage(phone, "YES");
+    await handleMessage(phone, "3");
+    await handleMessage(phone, "5");
+    const invite = await prisma.invitation.findFirst({
+      where: {
+        member: {
+          phoneNumber: phone,
+        },
+      },
+    });
+    expect(invite?.guests).toBe(5);
+  });
+});

--- a/app/messages/router.ts
+++ b/app/messages/router.ts
@@ -29,6 +29,23 @@ export async function handleMessage(fromNumber: string, message: string) {
     };
   }
 
+  switch (message.trim().toLowerCase()) {
+    case "help":
+      return {
+        response:
+          "Respond with any of the following commands: HELP, INVITATIONS",
+      };
+
+    case "invitations":
+      return {
+        response:
+          "To view or update invitations and RSVPs, use this link: " +
+          process.env.HOST_NAME +
+          "/memberLogin?token=" +
+          member.token,
+      };
+  }
+
   const latestInvite = await getLatestInvitation(member.id);
 
   if (latestInvite) {

--- a/app/messages/router.ts
+++ b/app/messages/router.ts
@@ -56,7 +56,7 @@ export async function handleMessage(fromNumber: string, message: string) {
         case "MAYBE": {
           await recordResponse({
             invitationId: latestInvite.id,
-            response: "RESPONDED_NO",
+            response: "RESPONDED_MAYBE",
           });
           return {
             response: "We'll follow up with you in a few days.",
@@ -68,14 +68,9 @@ export async function handleMessage(fromNumber: string, message: string) {
           };
         }
       }
-    } else if (
-      latestInvite.status === "RESPONDED_YES" &&
-      latestInvite.guests === null
-    ) {
-      let numGuests: number;
-      try {
-        numGuests = parseInt(message);
-      } catch (e) {
+    } else if (latestInvite.status === "RESPONDED_YES") {
+      const numGuests: number = parseInt(message);
+      if (isNaN(numGuests)) {
         return {
           response: "Please type a number between 1-10",
         };

--- a/app/models/event.server.ts
+++ b/app/models/event.server.ts
@@ -2,6 +2,7 @@ import { prisma } from "~/db.server";
 import { Prisma } from "@prisma/client";
 import type { Schedule } from "@prisma/client";
 import { getAllActiveMembers } from "./member.server";
+import { sendInvite } from "./invitation.server";
 
 // 1: Define a type that includes the relation to `Post`
 const eventWithInvitations = Prisma.validator<Prisma.EventArgs>()({
@@ -117,13 +118,7 @@ export async function sendInvitations({ eventId }: { eventId: Event["id"] }) {
       }
 
       console.debug(`Creating invite for ${member.phoneNumber} (${member.id})`);
-      return prisma.invitation.create({
-        data: {
-          status: "SENT",
-          eventId,
-          memberId: member.id,
-        },
-      });
+      return sendInvite({ memberId: member.id, eventId });
 
       // send a text
       // If there's an issue with sending, delete the invite
@@ -136,6 +131,8 @@ export async function sendInvitations({ eventId }: { eventId: Event["id"] }) {
     }
     return [];
   });
+
+  console.error(`Failed to create some invites.`, failures);
 
   return failures;
 }

--- a/app/models/invitation.server.ts
+++ b/app/models/invitation.server.ts
@@ -1,5 +1,5 @@
 import { prisma } from "~/db.server";
-import type { Invitation } from "@prisma/client";
+import type { Member, Event, Invitation } from "@prisma/client";
 
 export type { Invitation } from "@prisma/client";
 
@@ -70,6 +70,22 @@ export async function recordGuests({
     where: { id: invitationId },
     data: {
       guests: numGuests,
+    },
+  });
+}
+
+export async function sendInvite({
+  eventId,
+  memberId,
+}: {
+  eventId: Event["id"];
+  memberId: Member["id"];
+}) {
+  return prisma.invitation.create({
+    data: {
+      status: "SENT",
+      eventId,
+      memberId,
     },
   });
 }

--- a/app/routes/event/$eventId/sendInvites.ts
+++ b/app/routes/event/$eventId/sendInvites.ts
@@ -16,7 +16,6 @@ export async function action({ request, params }: ActionArgs) {
   invariant(eventId, "Event id is required");
 
   const failures = await sendInvitations({ eventId });
-  console.log(failures);
 
   return redirect("/event/" + eventId);
 }


### PR DESCRIPTION
* If you text "invitations" you get a login link -- could come up with a better name for this command or otherwise make the workflow more clear
* Add tests to the message router (In the process, I found some bugs!)

Maybe we want to just move _all_ the RSVP stuff into the web app instead of having the SMS-based API. Every text does cost money so we might as well just use the browser which is free.